### PR TITLE
Scrape area for Alderney Representatives

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -8,7 +8,7 @@ class MemberPage < Page
   end
 
   field :area do
-    noko.xpath("id('Breadcrumb')/li[5]/a").text.tidy
+    noko.xpath("id('Breadcrumb')/li")[-2].text.tidy
   end
 
   field :party do

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -10,7 +10,7 @@ class MemberPage < Page
   field :area do
     noko.xpath("id('Breadcrumb')/li")[-2]
         .text
-        .sub('Representatives', 'Representative')
+        .sub('Representatives', '')
         .tidy
   end
 

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -8,7 +8,10 @@ class MemberPage < Page
   end
 
   field :area do
-    noko.xpath("id('Breadcrumb')/li")[-2].text.tidy
+    noko.xpath("id('Breadcrumb')/li")[-2]
+        .text
+        .sub('Representatives', 'Representative')
+        .tidy
   end
 
   field :party do

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -8,7 +8,7 @@ class MemberPage < Page
   end
 
   field :area do
-    noko.xpath("id('Breadcrumb')/li")[-2]
+    noko.xpath("id('Breadcrumb')/li[last() - 1]")
         .text
         .sub('Representatives', '')
         .tidy


### PR DESCRIPTION
The area of members is pulled from the breadcrumbs of each member page. However, whilst the deputies are navigated to by "Guernsey Deputies -> _<Area>_ -> _<Member>_", the Alderney representatives are reached by following "Alderney Representatives -> _<Member>_". 

We were indexing the breadcrumb list from the left but as Alderney Representatives have fewer breadcrumbs, we weren't capturing anything. Instead, with this PR, we index the crumbs from the right as the area is always the second to last item.

This PR also handles the plural 'Representatives', substituting it for the singular.