### PR TITLE
Avoid writing empty rows to database

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -16,5 +16,5 @@ warn "Found #{member_list[:members].count} members"
 
 member_list[:members].shuffle.each do |mem|
   member = MemberPage.new(mem[:url]).to_h
-  ScraperWiki.save_sqlite([:name], member)
+  ScraperWiki.save_sqlite([:name], member) unless member[:name].empty?
 end


### PR DESCRIPTION
Twice, the re-builder has failed to build Guernsey. On investigation it has been discovered that on each occasion the database has contained a row of empty fields. 

This PR amends the scraper so that it avoids writing to the DB when a :name field has not been recorded.

(For reference, the Rollbar error is here: https://rollbar.com/everypolitician/rebuilder/items/896/)