### PR TITLE
Skip member pages that don't return a 200 status

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -15,6 +15,11 @@ member_list = AllMembersPage.new(response: Scraped::Request.new(url: url).respon
 warn "Found #{member_list.size} members"
 
 member_list.shuffle.each do |mem|
-  member = MemberPage.new(response: Scraped::Request.new(url: mem[:url]).response)
+  response = Scraped::Request.new(url: mem[:url]).response
+  if response.status != 200
+    warn "Got response status #{response.status} from #{response.url}. Skipping"
+    next
+  end
+  member = MemberPage.new(response: response)
   ScraperWiki.save_sqlite([:name], member.to_h)
 end


### PR DESCRIPTION
If a member page has an error on it then it will return a 302 status redirecting to a generic error page. We don't want to scrape this error page, as it results in an empty row being added to the scraper's database. So just skip any member pages that don't return a 200 status.

This supersedes #3 